### PR TITLE
Fix @source_url

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule TailwindVariants.MixProject do
 
   @version "0.1.0"
   @description "Tailwind Variants for Elixir - A port of the tailwind-variants library"
-  @source_url "https://github.com/guess/tailwind_variants"
+  @source_url "https://github.com/guess/tailwind-variants"
 
   def project do
     [


### PR DESCRIPTION
Fixes a typo in the `@source_url` that was causing the link from hex.pm to 404