### PR TITLE
Allow tw/2 to merge Tailwind classes as strings, lists

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+name: Test
+
+on: push
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      MIX_ENV: test
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Elixir
+      uses: erlef/setup-beam@v1
+      with:
+        elixir-version: '1.18.4'
+        otp-version: '27.3.3'
+
+    - uses: actions/cache@v4
+      with:
+        path: |
+          deps
+          _build
+        key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-mix-
+
+    - run: mix deps.get
+    - run: mix test

--- a/lib/tailwind_variants.ex
+++ b/lib/tailwind_variants.ex
@@ -142,7 +142,7 @@ defmodule TailwindVariants do
   end
 
   @doc """
-  Applies props to a component to generate class names.
+  Applies props to a component to generate class names or simply merges Tailwind classes.
 
   ## Parameters
 
@@ -171,12 +171,23 @@ defmodule TailwindVariants do
       ...> })
       iex> tw(component, %{color: "primary"})
       "font-medium bg-blue-500"
+
+      iex> tw("p-3", "p-4 text-red-500")
+      "p-4 text-red-500"
+
   """
   def tw(component_or_slot, props \\ %{})
 
   # Slot function map case
   def tw(slot_fn, props) when is_function(slot_fn, 1) do
     slot_fn.(props)
+  end
+
+  def tw(classes1, classes2)
+      when (is_list(classes1) or is_binary(classes1) or is_nil(classes1)) and
+             (is_list(classes2) or is_binary(classes2) or is_nil(classes2)) do
+    classes = List.wrap(classes1) ++ List.wrap(classes2)
+    Utils.merge_class_names(classes, %{tw_merge: true})
   end
 
   # Direct class merging - string or list of classes

--- a/test/support/test_assertions.ex
+++ b/test/support/test_assertions.ex
@@ -53,6 +53,7 @@ defmodule TailwindVariants.TestAssertions do
   Empty or nil values are filtered out.
   """
   def normalize_classes(nil), do: []
+  def normalize_classes([]), do: []
   def normalize_classes(""), do: []
 
   def normalize_classes(classes) when is_binary(classes) do

--- a/test/tailwind_variants_test.exs
+++ b/test/tailwind_variants_test.exs
@@ -197,6 +197,24 @@ defmodule TailwindVariantsTest do
       # Should just concatenate classes without merging
       assert_classes_match("p-4 text-red-500 p-6 text-lg", classes)
     end
+
+    test "merges classes when given as strings, lists or nils" do
+      class1_str = "p-3"
+      class1_list = ["p-3"]
+
+      class2_str = "p-4 text-red-500"
+      class2_list = ["p-4", "text-red-500"]
+      class2_list_joined = ["p-4 text-red-500"]
+
+      assert_classes_match("p-4 text-red-500", tw(class1_str, class2_str))
+      assert_classes_match("p-4 text-red-500", tw(class1_str, class2_list))
+      assert_classes_match("p-4 text-red-500", tw(class1_list, class2_list))
+      assert_classes_match("p-4 text-red-500", tw(class1_str, class2_list_joined))
+      assert_classes_match("p-4 text-red-500", tw(nil, class2_str))
+
+      assert_classes_match("p-3", tw(class1_str, nil))
+      assert_classes_match([], tw(nil, nil))
+    end
   end
 
   describe "tw/2 - compound variants" do


### PR DESCRIPTION
Thank you for this library first of all. :heart_hands: 


As mentioned in the docs (https://hexdocs.pm/tailwind_variants/readme.html#class-merging), I'd like to use `tw/2` to simply merge Tailwind classes, which this commit implements.

My use case is that I'd like to create Phoenix heex components with the variants, but then also give the caller the possibility to apply extra custom classes that will be merged.

```ex
attr :color, :string
attr :rest, :global
attr :border, :boolean, default: false
attr :size, :string

slot :inner_block, required: true

def badge(assigns) do
  class =
    tw(variant(), %{color: assigns[:color], size: assigns[:size], border: assigns[:border]})
   |> tw(assigns[:class])
   # this does not work (yet) :)

  assigns = assign(assigns, class: class)

  ~H"""
  <span class={@class} {@rest}>{render_slot(@inner_block)}</span>
  """
end

defp variant() do
  tv(%{
   # actual variant here...
  })
end
´´´